### PR TITLE
Update `tunes` data when new `tunes` data is provided

### DIFF
--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -349,7 +349,7 @@ export default class BlockManager extends Module {
       id: block.id,
       tool: block.name,
       data: Object.assign({}, existingData, data),
-      tunes: block.tunes,
+      tunes: data.tunes ?? block.tunes,
     });
 
     const blockIndex = this.getBlockIndex(block);


### PR DESCRIPTION
AFAIK, when you update block using `editor.blocks.update` method, only `data` attribute is merged and updated. I believe `tunes` data should be updated if provided.